### PR TITLE
Fix destructor and Shutdown method exception specifications in ThreadSafeQueue

### DIFF
--- a/tests/threadsafe_queue_test.cpp
+++ b/tests/threadsafe_queue_test.cpp
@@ -12,6 +12,8 @@ namespace {
 
 class ThreadSafeQueueFixture : public ::testing::Test
 {
+public:
+    ~ThreadSafeQueueFixture() noexcept = default;
 protected:
     threadsafe_queue::ThreadSafeQueue<int> queue{};
 };
@@ -27,7 +29,10 @@ struct PerfTestParams
 class ThreadSafeQueueFixtureWithParams
     : public ThreadSafeQueueFixture
     , public ::testing::WithParamInterface<PerfTestParams>
-{};
+{
+public:
+    ~ThreadSafeQueueFixtureWithParams() noexcept = default;
+};
 
 template <typename Unit>
 concept PerformanceUnit = std::is_same_v<Unit, std::chrono::milliseconds> || std::is_same_v<Unit, std::chrono::microseconds> ||

--- a/thread_safe_queue/CMakeLists.txt
+++ b/thread_safe_queue/CMakeLists.txt
@@ -6,7 +6,7 @@ set(MODULES_DIR ${SOURCE_DIR}/modules)
 
 add_library(${PROJECT_NAME})
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
-target_compile_options(${PROJECT_NAME} PRIVATE -pipe -Wall -Wextra -pedantic-errors -pedantic -Wno-error=overriding-method-mismatch)
+target_compile_options(${PROJECT_NAME} PRIVATE -pipe -Wall -Wextra -pedantic-errors -pedantic)
 
 target_sources(${PROJECT_NAME}
     PUBLIC

--- a/thread_safe_queue/CMakeLists.txt
+++ b/thread_safe_queue/CMakeLists.txt
@@ -6,7 +6,7 @@ set(MODULES_DIR ${SOURCE_DIR}/modules)
 
 add_library(${PROJECT_NAME})
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
-target_compile_options(${PROJECT_NAME} PRIVATE -pipe -Wall -Wextra -pedantic-errors -pedantic)
+target_compile_options(${PROJECT_NAME} PRIVATE -pipe -Wall -Wextra -pedantic-errors -pedantic -Wno-error=overriding-method-mismatch)
 
 target_sources(${PROJECT_NAME}
     PUBLIC

--- a/thread_safe_queue/src/modules/threadsafe_queue.ixx
+++ b/thread_safe_queue/src/modules/threadsafe_queue.ixx
@@ -21,7 +21,7 @@ public:
     ThreadSafeQueue &operator=(const ThreadSafeQueue &other) = delete;
     ThreadSafeQueue &operator=(ThreadSafeQueue &&) = delete;
 
-    ~ThreadSafeQueue() noexcept
+    ~ThreadSafeQueue() noexcept(false)
     {
         Shutdown();
     }
@@ -80,7 +80,7 @@ public:
         m_head = std::move(m_head->next);
     }
 
-    void Shutdown() noexcept
+    void Shutdown()
     {
         {
             // Shutdown must acquire m_headMutex to avoid a race condition with WaitAndPop.


### PR DESCRIPTION
std::scoped_lock throws exception